### PR TITLE
Upgrade fcsc (azure) charts to k8s v1.25

### DIFF
--- a/ckan/templates/ckan-hpa.yaml
+++ b/ckan/templates/ckan-hpa.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.ckan.hpa.enable }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ .Values.general.projectId }}-hpa

--- a/ckan/templates/datapusher-hpa.yaml
+++ b/ckan/templates/datapusher-hpa.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.datapusher.hpa.enable }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ .Values.general.projectId }}-datapusher-hpa

--- a/ckan/templates/job-create-db-backups.yaml
+++ b/ckan/templates/job-create-db-backups.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: job-ckan-db-backup


### PR DESCRIPTION
The changelog is available here https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-25
The following are not available in v1.25 anymore.

- HPA: apiVersion: autoscaling/v2beta1
- Cronjob: apiVersion: batch/v1beta1

They are replaced by

- HPA: apiVersion: autoscaling/v2
- Cronjob: apiVersion: batch/v1
